### PR TITLE
feat: use summary_large_image for twitter card meta property

### DIFF
--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -15,7 +15,7 @@ export default createHandler(() => (
             property="description"
             content="World of Tanks Vehicle Guessing Game"
           />
-          <meta property="twitter:card" content="summary"></meta>
+          <meta property="twitter:card" content="summary_large_image"></meta>
           <meta property="twitter:title" content="WoTdle"></meta>
           <meta
             property="twitter:description"


### PR DESCRIPTION
[feat: 🔍 use summary_large_image for twitter card meta property](https://github.com/AltwargEvan/WoTdle/commit/103339a8a062943a9db4f14b8bcae2588693034d)

